### PR TITLE
feat(clickhouse): add v25.4, v25.5, v25.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,8 @@ jobs:
         tags:
           - clickhouse_24.11
           - clickhouse_25.3
+          - clickhouse_25.4
+          - clickhouse_25.5
           - clickhouse_24.10
           - clickhouse_25.2
           - clickhouse_24.9
@@ -227,6 +229,7 @@ jobs:
           - clickhouse_24.8
           - clickhouse_24.12
           - clickhouse_25.1
+          - clickhouse_25.6
           - clickhouse_24.3
           - clickhouse_24.5
     env:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:clickhouse_25.1`](#clickhouse-serverclickhouse_251)
     - [`ghcr.io/duyet/docker-images:clickhouse_25.2`](#clickhouse-serverclickhouse_252)
     - [`ghcr.io/duyet/docker-images:clickhouse_25.3`](#clickhouse-serverclickhouse_253)
+    - [`ghcr.io/duyet/docker-images:clickhouse_25.4`](#clickhouse-serverclickhouse_254)
+    - [`ghcr.io/duyet/docker-images:clickhouse_25.5`](#clickhouse-serverclickhouse_255)
+    - [`ghcr.io/duyet/docker-images:clickhouse_25.6`](#clickhouse-serverclickhouse_256)
 - [`debezium`](#debezium)
     - [`ghcr.io/duyet/docker-images:debezium_1.9.5.Final`](#debeziumdebezium_195final)
     - [`ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1`](#debeziumdebezium_200beta1)
@@ -264,6 +267,36 @@ FROM ghcr.io/duyet/docker-images:clickhouse_25.3
 ```
 
 
+### [`clickhouse-server/clickhouse_25.4`](clickhouse-server/clickhouse_25.4/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.4
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.4
+```
+
+
+### [`clickhouse-server/clickhouse_25.5`](clickhouse-server/clickhouse_25.5/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.5
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.5
+```
+
+
 ### [`clickhouse-server/clickhouse_24.10`](clickhouse-server/clickhouse_24.10/Dockerfile)
 
 Install from the command line
@@ -381,6 +414,21 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:clickhouse_25.1
+```
+
+
+### [`clickhouse-server/clickhouse_25.6`](clickhouse-server/clickhouse_25.6/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.6
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.6
 ```
 
 

--- a/clickhouse-server/clickhouse_25.4/Dockerfile
+++ b/clickhouse-server/clickhouse_25.4/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.4
+
+COPY --chmod=755 clickhouse-server/clickhouse_25.4/config.d/ /etc/clickhouse-server/config.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.4/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.4/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_25.4/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_25.4/config.d/keeper.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+	<zookeeper>
+		<node>
+			<host>keeper</host>
+			<port>2181</port>
+		</node>
+	</zookeeper>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.4/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_25.4/config.d/setting_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </part_log>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>100</flush_interval_milliseconds>
+    <collect_interval_milliseconds>100</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>100</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.4/config.d/storage.xml
+++ b/clickhouse-server/clickhouse_25.4/config.d/storage.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/tmp/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/tmp/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.4/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_25.4/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    BACKUP TABLE data_lake.events TO Disk('backups', 'init_backup.zip');
+EOSQL

--- a/clickhouse-server/clickhouse_25.4/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_25.4/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_25.4/keeper/healthcheck.sh
+++ b/clickhouse-server/clickhouse_25.4/keeper/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+date && OK=$(
+    exec 3<>/dev/tcp/127.0.0.1/2181
+    printf "ruok" >&3
+    IFS=
+    tee <&3
+    exec 3<&-
+)
+
+if [[ "$OK" == "imok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/clickhouse-server/clickhouse_25.4/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_25.4/keeper/keeper.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.5/Dockerfile
+++ b/clickhouse-server/clickhouse_25.5/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.5
+
+COPY --chmod=755 clickhouse-server/clickhouse_25.5/config.d/ /etc/clickhouse-server/config.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.5/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.5/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_25.5/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_25.5/config.d/keeper.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+	<zookeeper>
+		<node>
+			<host>keeper</host>
+			<port>2181</port>
+		</node>
+	</zookeeper>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.5/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_25.5/config.d/setting_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </part_log>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>100</flush_interval_milliseconds>
+    <collect_interval_milliseconds>100</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>100</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.5/config.d/storage.xml
+++ b/clickhouse-server/clickhouse_25.5/config.d/storage.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/tmp/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/tmp/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.5/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_25.5/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    BACKUP TABLE data_lake.events TO Disk('backups', 'init_backup.zip');
+EOSQL

--- a/clickhouse-server/clickhouse_25.5/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_25.5/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_25.5/keeper/healthcheck.sh
+++ b/clickhouse-server/clickhouse_25.5/keeper/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+date && OK=$(
+    exec 3<>/dev/tcp/127.0.0.1/2181
+    printf "ruok" >&3
+    IFS=
+    tee <&3
+    exec 3<&-
+)
+
+if [[ "$OK" == "imok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/clickhouse-server/clickhouse_25.5/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_25.5/keeper/keeper.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.6/Dockerfile
+++ b/clickhouse-server/clickhouse_25.6/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.6
+
+COPY --chmod=755 clickhouse-server/clickhouse_25.6/config.d/ /etc/clickhouse-server/config.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.6/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.6/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_25.6/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_25.6/config.d/keeper.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+	<zookeeper>
+		<node>
+			<host>keeper</host>
+			<port>2181</port>
+		</node>
+	</zookeeper>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.6/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_25.6/config.d/setting_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </part_log>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>100</flush_interval_milliseconds>
+    <collect_interval_milliseconds>100</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>100</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.6/config.d/storage.xml
+++ b/clickhouse-server/clickhouse_25.6/config.d/storage.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/tmp/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/tmp/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.6/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_25.6/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    BACKUP TABLE data_lake.events TO Disk('backups', 'init_backup.zip');
+EOSQL

--- a/clickhouse-server/clickhouse_25.6/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_25.6/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_25.6/keeper/healthcheck.sh
+++ b/clickhouse-server/clickhouse_25.6/keeper/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+date && OK=$(
+    exec 3<>/dev/tcp/127.0.0.1/2181
+    printf "ruok" >&3
+    IFS=
+    tee <&3
+    exec 3<&-
+)
+
+if [[ "$OK" == "imok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/clickhouse-server/clickhouse_25.6/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_25.6/keeper/keeper.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>


### PR DESCRIPTION
## Summary by Sourcery

Add support for ClickHouse server versions 25.4, 25.5, and 25.6 by introducing new Docker images with default configurations, initialization scripts, healthchecks, and updating CI and documentation.

New Features:
- Introduce Docker images for ClickHouse server versions 25.4, 25.5, and 25.6

Enhancements:
- Add Dockerfiles, keeper entrypoints, and init-db scripts for each new ClickHouse version
- Provide default log, storage, keeper, and ZooKeeper configurations with healthcheck scripts
- Update CI workflow to include building and testing of ClickHouse 25.4, 25.5, and 25.6 images

Documentation:
- Update README to list and document the new ClickHouse 25.4–25.6 images