### PR TITLE
feat: add nodejs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,6 +349,69 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  node:
+    name: Build node
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - node_24
+          - node_22
+    env:
+      IMAGE_NAME: node
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
   debezium:
     name: Build debezium
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:gcloud_debian_python3`](#gcloudgcloud_debian_python3)
 - [`kubeconform`](#kubeconform)
     - [`ghcr.io/duyet/docker-images:kubeconform_latest`](#kubeconformkubeconform_latest)
+- [`node`](#node)
+    - [`ghcr.io/duyet/docker-images:node_22`](#nodenode_22)
+    - [`ghcr.io/duyet/docker-images:node_24`](#nodenode_24)
 - [`rust`](#rust)
     - [`ghcr.io/duyet/docker-images:athena`](#rustathena)
     - [`ghcr.io/duyet/docker-images:cargo-audit`](#rustcargo-audit)
@@ -476,6 +479,38 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:kubeconform_latest
+```
+
+
+## `node`
+
+### [`node/node_24`](node/node_24/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_24
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_24
+```
+
+
+### [`node/node_22`](node/node_22/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_22
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_22
 ```
 
 

--- a/node/node_22/Dockerfile
+++ b/node/node_22/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:22

--- a/node/node_24/Dockerfile
+++ b/node/node_24/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:24


### PR DESCRIPTION
## Summary by Sourcery

Add support for Node.js by introducing Dockerfiles for Node.js 22 and 24, integrating a CI job to build and push these images, and updating documentation with usage instructions

New Features:
- Provide Dockerfiles for Node.js 22 and Node.js 24 base images

CI:
- Add 'node' job in CI workflow to build and push multi-arch Node.js images for tags node_22 and node_24

Documentation:
- Document the new Node.js images with pull and usage instructions in the README