### PR TITLE
feat(debian): add debian:stable-slim base image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,68 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  debian:
+    name: Build debian
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - stable-slim
+    env:
+      IMAGE_NAME: debian
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
   python:
     name: Build python
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1`](#debeziumdebezium_200beta1)
     - [`ghcr.io/duyet/docker-images:debezium_2.0.0.Beta2`](#debeziumdebezium_200beta2)
     - [`ghcr.io/duyet/docker-images:debezium_3.0.0.Final`](#debeziumdebezium_300final)
+- [`debian`](#debian)
+    - [`ghcr.io/duyet/docker-images:stable-slim`](#debianstable-slim)
 - [`gcloud`](#gcloud)
     - [`ghcr.io/duyet/docker-images:gcloud_alpine_python39`](#gcloudgcloud_alpine_python39)
     - [`ghcr.io/duyet/docker-images:gcloud_debian_python3`](#gcloudgcloud_debian_python3)
@@ -133,6 +135,23 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:gcloud_alpine_python39
+```
+
+
+## `debian`
+
+### [`debian/stable-slim`](debian/stable-slim/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:stable-slim
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:stable-slim
 ```
 
 

--- a/debian/stable-slim/Dockerfile
+++ b/debian/stable-slim/Dockerfile
@@ -1,0 +1,1 @@
+FROM debian:stable-slim


### PR DESCRIPTION
## Summary

Add new `debian:stable-slim` base image to the docker-images collection.

## Changes

- Created `debian/stable-slim/` directory with passthrough Dockerfile
- Regenerated CI workflow to include debian image builds
- Updated README with debian image documentation

## Test plan

- [x] `uv run python gen.py` generates workflow correctly
- [ ] CI builds images for linux/amd64 and linux/arm64
- [ ] Images publish successfully to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new debian:stable-slim base image and integrate it into the image build and publish pipeline.

New Features:
- Introduce a debian/stable-slim Docker image based on the official debian:stable-slim image.

Enhancements:
- Extend the CI workflow to build and publish the debian stable-slim image for multiple platforms.
- Document the new debian stable-slim image usage and pull instructions in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Debian stable-slim container image variant supporting AMD64 and ARM64 architectures for multi-platform deployments.

* **Documentation**
  * Updated the image catalog with pull instructions and base image usage examples for the new Debian variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->