### PR TITLE
feat(alpine): add alpine:3.19 base image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,68 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  alpine:
+    name: Build alpine
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - 3.19
+    env:
+      IMAGE_NAME: alpine
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
   debian:
     name: Build debian
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ python3 gen.py
 # Image lists
 
 <!-- BEGIN IMAGE LIST -->
+- [`alpine`](#alpine)
+    - [`ghcr.io/duyet/docker-images:3.19`](#alpine319)
 - [`bun`](#bun)
     - [`ghcr.io/duyet/docker-images:bun_1`](#bunbun_1)
     - [`ghcr.io/duyet/docker-images:bun_1.3`](#bunbun_13)
@@ -135,6 +137,23 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:gcloud_alpine_python39
+```
+
+
+## `alpine`
+
+### [`alpine/3.19`](alpine/3.19/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:3.19
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:3.19
 ```
 
 

--- a/alpine/3.19/Dockerfile
+++ b/alpine/3.19/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19


### PR DESCRIPTION
## Summary

Add alpine:3.19 base image to docker-images collection.

## Changes

- Created `alpine/3.19/` directory with passthrough Dockerfile
- Regenerated CI workflow to include alpine image builds
- Updated README with alpine image documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new alpine:3.19 base image and integrate it into the build pipeline and documentation.

New Features:
- Introduce an alpine:3.19 base image Dockerfile.
- Document usage of the alpine:3.19 image in the README.

CI:
- Extend the CI workflow to build and publish the alpine:3.19 image when relevant files change.