### PR TITLE
feat(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -43,7 +43,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,12 +52,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -68,7 +68,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -93,7 +93,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -105,7 +105,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -114,12 +114,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -130,7 +130,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -155,7 +155,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -167,7 +167,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -176,12 +176,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -192,7 +192,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -218,7 +218,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -230,7 +230,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -239,12 +239,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -255,7 +255,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -281,7 +281,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -293,7 +293,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -302,12 +302,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -318,7 +318,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -343,7 +343,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -355,7 +355,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -364,12 +364,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -380,7 +380,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -411,7 +411,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -423,7 +423,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -432,12 +432,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -448,7 +448,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -475,7 +475,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -487,7 +487,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -496,12 +496,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -512,7 +512,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -541,7 +541,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -553,7 +553,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -562,12 +562,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -578,7 +578,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -619,7 +619,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -631,7 +631,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -640,12 +640,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -656,7 +656,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -681,7 +681,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -693,7 +693,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -702,12 +702,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -718,7 +718,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -748,7 +748,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -760,7 +760,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -769,12 +769,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -785,7 +785,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}
@@ -813,7 +813,7 @@ jobs:
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -825,7 +825,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -834,12 +834,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -850,7 +850,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}

--- a/gen.py
+++ b/gen.py
@@ -67,7 +67,7 @@ jobs:
     {%- raw %}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -79,7 +79,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -88,12 +88,12 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         if: steps.changes.outputs.src == 'true'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
@@ -104,7 +104,7 @@ jobs:
       - name: Build and push
         if: steps.changes.outputs.src == 'true'
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

Update GitHub Actions to Node.js 24 compatible versions to resolve deprecation notices.

## Changes

- `actions/checkout@v3` → `@v4`
- `docker/login-action@v2` → `@v3`
- `docker/setup-buildx-action@v1` → `@v3`
- `docker/metadata-action@v4` → `@v5`
- `docker/build-push-action@v4` → `@v6`

## Context

Node.js 20 actions are deprecated and will be removed in September 2026. These upgrades ensure CI continues working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update CI workflows and templates to use newer Docker and checkout GitHub Actions versions compatible with current Node.js runners.

CI:
- Bump actions/checkout from v3 to v4 across all CI workflows and their generator template.
- Upgrade Docker-related GitHub Actions (login, setup-buildx, metadata, build-push) to their latest major versions in CI workflows and templates.