### PR TITLE
feat(images): add node alpine and docker 27 variants

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,69 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
+  docker:
+    name: Build docker
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - docker_27_dind
+          - docker_27_cli
+    env:
+      IMAGE_NAME: docker
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
   debian:
     name: Build debian
     runs-on: ubuntu-latest
@@ -742,6 +805,7 @@ jobs:
           - node_24-slim
           - node_24
           - node_22
+          - node_22.14.0_alpine
           - node_20-slim
     env:
       IMAGE_NAME: node

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:debezium_3.0.0.Final`](#debeziumdebezium_300final)
 - [`debian`](#debian)
     - [`ghcr.io/duyet/docker-images:stable-slim`](#debianstable-slim)
+- [`docker`](#docker)
+    - [`ghcr.io/duyet/docker-images:docker_27_cli`](#dockerdocker_27_cli)
+    - [`ghcr.io/duyet/docker-images:docker_27_dind`](#dockerdocker_27_dind)
 - [`gcloud`](#gcloud)
     - [`ghcr.io/duyet/docker-images:gcloud_alpine_python39`](#gcloudgcloud_alpine_python39)
     - [`ghcr.io/duyet/docker-images:gcloud_debian_python3`](#gcloudgcloud_debian_python3)
@@ -82,6 +85,7 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:node_20-slim`](#nodenode_20-slim)
     - [`ghcr.io/duyet/docker-images:node_22`](#nodenode_22)
     - [`ghcr.io/duyet/docker-images:node_22-slim`](#nodenode_22-slim)
+    - [`ghcr.io/duyet/docker-images:node_22.14.0_alpine`](#nodenode_22140_alpine)
     - [`ghcr.io/duyet/docker-images:node_24`](#nodenode_24)
     - [`ghcr.io/duyet/docker-images:node_24-slim`](#nodenode_24-slim)
 - [`postgres`](#postgres)
@@ -154,6 +158,38 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:3.19
+```
+
+
+## `docker`
+
+### [`docker/docker_27_dind`](docker/docker_27_dind/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:docker_27_dind
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:docker_27_dind
+```
+
+
+### [`docker/docker_27_cli`](docker/docker_27_cli/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:docker_27_cli
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:docker_27_cli
 ```
 
 
@@ -834,6 +870,21 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:node_22
+```
+
+
+### [`node/node_22.14.0_alpine`](node/node_22.14.0_alpine/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_22.14.0_alpine
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_22.14.0_alpine
 ```
 
 

--- a/docker/docker_27_cli/Dockerfile
+++ b/docker/docker_27_cli/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker:27-cli

--- a/docker/docker_27_dind/Dockerfile
+++ b/docker/docker_27_dind/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker:27-dind

--- a/node/node_22.14.0_alpine/Dockerfile
+++ b/node/node_22.14.0_alpine/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:22.14.0-alpine


### PR DESCRIPTION
## Summary
- add 
- add 
- add 
- regenerate  and  via Generated workflows to .github/workflows/ci.yaml
Generated README.md

## Notes
-  already exists at 
-  already exists at

## Summary by Sourcery

Add new Docker 27 and Node 22.14.0 alpine image variants and integrate them into the CI build workflow and README catalog.

New Features:
- Introduce docker_27_cli and docker_27_dind image variants based on official Docker 27 images.
- Add a node_22.14.0_alpine image variant based on the official Node 22.14.0 alpine image.

Enhancements:
- Extend CI workflow to build and publish the new Docker 27 and Node 22.14.0 alpine image variants.
- Update README to document the new Docker and Node image variants and usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker 27 container images (CLI and DIND variants) now available
  * Node 22.14.0 Alpine container image now available

* **Documentation**
  * Added documentation for new container images with pull commands and usage examples

* **Chores**
  * Updated CI/CD pipeline to build and push new container images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->