### PR TITLE
fix(ci): remove date-suffixed docker tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -124,7 +123,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -187,7 +185,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -249,7 +246,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -312,7 +308,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -375,7 +370,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -437,7 +431,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -505,7 +498,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -569,7 +561,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -635,7 +626,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -713,7 +703,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -775,7 +764,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -843,7 +831,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push
@@ -908,7 +895,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push

--- a/gen.py
+++ b/gen.py
@@ -98,7 +98,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}
           tags: |
             type=raw,value=${{ matrix.tags }}
-            type=raw,value=${{ matrix.tags }}-{{date 'YYYYMMDD'}}
             type=sha,format=short
 
       - name: Build and push


### PR DESCRIPTION
## Summary
- remove date-suffixed image tag generation () in workflow generator
- keep only stable tag and sha tag in docker metadata
- regenerate 

## Result
- images publish with tags like , , 
- date tags like  are no longer generated

## Summary by Sourcery

Build:
- Update GitHub Actions workflow and generator to remove YYYYMMDD-suffixed Docker tags from docker/metadata-action configuration.