### PR TITLE
chore(ci): auto-delete untagged ghcr image versions

### DIFF
--- a/.github/workflows/cleanup-untagged-images.yaml
+++ b/.github/workflows/cleanup-untagged-images.yaml
@@ -1,0 +1,22 @@
+name: Cleanup Untagged GHCR Images
+
+on:
+  schedule:
+    - cron: '15 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged container versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: docker-images
+          package-type: container
+          owner: duyet
+          min-versions-to-keep: 30
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Summary
- add scheduled workflow to remove untagged GHCR versions for 
- run daily and allow manual dispatch
- keep latest 30 versions and delete only untagged versions

## Scope
- package: 
- no tagged images are removed

## Summary by Sourcery

CI:
- Introduce a daily and manually-triggerable workflow that deletes untagged GHCR container image versions, keeping the latest 30 versions.