### PR TITLE
fix(gen): harden path handling and README marker checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,9 @@ uv run python gen.py --dry-run
 
 # Get help
 uv run python gen.py --help
+
+# Inspect recent image/workflow changes
+git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso
 ```
 
 ### CI/CD Pipeline
@@ -65,7 +68,6 @@ GitHub Actions automatically:
 - Supports multi-architecture builds (linux/amd64, linux/arm64)
 - Tags images with:
   - The image tag name
-  - Date-stamped version (`<tag>-YYYYMMDD`)
   - Git SHA
 - Publishes to `ghcr.io/duyet/docker-images:<tag>`
 

--- a/gen.py
+++ b/gen.py
@@ -2,25 +2,26 @@
 
 import argparse
 import os
+from pathlib import Path
 
 import jinja2
 
 
-def scan_images():
+def scan_images(repo_root):
     """
     Scan a project for all the files and directories.
     """
-    current_dir = os.getcwd()
     projects = {}
 
     # Scan the image_name is the directory in top level
     # The image_tag is the directory in the image_name directory
-    for image_name in os.listdir(current_dir):
-        if os.path.isdir(image_name):
+    for image_name in os.listdir(repo_root):
+        image_dir = repo_root / image_name
+        if image_dir.is_dir():
             projects[image_name] = []
-            for image_tag in os.listdir(image_name):
-                check = os.path.join(image_name, image_tag, "Dockerfile")
-                if os.path.isfile(check):
+            for image_tag in os.listdir(image_dir):
+                check = image_dir / image_tag / "Dockerfile"
+                if check.is_file():
                     projects[image_name].append(image_tag)
 
     # Filter out the empty image_tags
@@ -194,7 +195,8 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    images = scan_images()
+    repo_root = Path(__file__).resolve().parent
+    images = scan_images(repo_root)
     workflows = build_workflows(images)
 
     if args.dry_run:
@@ -202,7 +204,7 @@ if __name__ == "__main__":
         raise SystemExit(0)
 
     # Write the workflows to the github workflows directory
-    target = ".github/workflows/ci.yaml"
+    target = repo_root / ".github/workflows/ci.yaml"
     with open(target, "w", encoding="utf-8") as f:
         f.write(workflows)
         print(f"Generated workflows to {target}")
@@ -211,14 +213,17 @@ if __name__ == "__main__":
     # Replace content between <!-- BEGIN IMAGE LIST --> and <!-- END IMAGE LIST -->
     # with the list of images
     readme_content = build_readme(images)
-    with open("README.md", "r", encoding="utf-8") as f:
+    readme_path = repo_root / "README.md"
+    with open(readme_path, "r", encoding="utf-8") as f:
         begin_marker = "<!-- BEGIN IMAGE LIST -->"
         end_marker = "<!-- END IMAGE LIST -->"
         content = f.read()
         start = content.find(begin_marker)
         end = content.find(end_marker)
+        if start == -1 or end == -1 or start >= end:
+            raise ValueError("README markers not found or invalid order")
         content = content[:start] + begin_marker + readme_content + content[end:]
 
-    with open("README.md", "w", encoding="utf-8") as f:
+    with open(readme_path, "w", encoding="utf-8") as f:
         f.write(content)
         print("Generated README.md")


### PR DESCRIPTION
## Summary
- anchor `gen.py` scanning/writes to repository root based on script location
- fail fast when README image-list markers are missing or in invalid order
- sync `CLAUDE.md` CI tag docs with current workflow behavior and add a recent-change audit command

## Evidence
- no commits exist after the last automation run in this repo, so the scan used the allowed fallback window (last 7 days)
- commit `a4157e7` removed date-suffixed tags from generated workflow, but `CLAUDE.md` still documented date-stamped tags

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py --dry-run`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined CI/CD image tagging documentation by clarifying core tag components and removing outdated formatting guidance.

* **New Features**
  * Added developer guidance command for inspecting recent image and workflow changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->