### PR TITLE
fix(gen): stabilize output order and maintain core memory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,68 +18,6 @@ env:
 
 
 jobs:
-  gcloud:
-    name: Build gcloud
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - gcloud_debian_python3
-          - gcloud_alpine_python39
-    env:
-      IMAGE_NAME: gcloud
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
   alpine:
     name: Build alpine
     runs-on: ubuntu-latest
@@ -141,16 +79,158 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
-  docker:
-    name: Build docker
+  bun:
+    name: Build bun
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tags:
-          - docker_27_dind
-          - docker_27_cli
+          - bun_1
+          - bun_1.3
+          - bun_latest
     env:
-      IMAGE_NAME: docker
+      IMAGE_NAME: bun
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  clickhouse-server:
+    name: Build clickhouse-server
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - clickhouse_24.10
+          - clickhouse_24.11
+          - clickhouse_24.12
+          - clickhouse_24.3
+          - clickhouse_24.5
+          - clickhouse_24.6
+          - clickhouse_24.7
+          - clickhouse_24.8
+          - clickhouse_24.9
+          - clickhouse_25.1
+          - clickhouse_25.2
+          - clickhouse_25.3
+          - clickhouse_25.4
+          - clickhouse_25.5
+          - clickhouse_25.6
+          - clickhouse_25.7
+          - clickhouse_25.8
+    env:
+      IMAGE_NAME: clickhouse-server
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  debezium:
+    name: Build debezium
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - debezium_1.9.5.Final
+          - debezium_2.0.0.Beta1
+          - debezium_2.0.0.Beta2
+          - debezium_3.0.0.Final
+    env:
+      IMAGE_NAME: debezium
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
@@ -212,6 +292,323 @@ jobs:
           - stable-slim
     env:
       IMAGE_NAME: debian
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  docker:
+    name: Build docker
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - docker_27_cli
+          - docker_27_dind
+    env:
+      IMAGE_NAME: docker
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  gcloud:
+    name: Build gcloud
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - gcloud_alpine_python39
+          - gcloud_debian_python3
+    env:
+      IMAGE_NAME: gcloud
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  kubeconform:
+    name: Build kubeconform
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - kubeconform_latest
+    env:
+      IMAGE_NAME: kubeconform
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  node:
+    name: Build node
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - node_20
+          - node_20-slim
+          - node_22
+          - node_22-slim
+          - node_22.14.0_alpine
+          - node_24
+          - node_24-slim
+    env:
+      IMAGE_NAME: node
+      IMAGE_TAG: '${{ matrix.tags }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+             src:
+              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
+              - '.github/workflows/ci.yaml'
+
+      - name: Log in to the Container registry
+        if: steps.changes.outputs.src == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.changes.outputs.src == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=${{ matrix.tags }}
+            type=sha,format=short
+
+      - name: Build and push
+        if: steps.changes.outputs.src == 'true'
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: ${{ github.workspace }}
+          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+
+      - name: Image digest
+        if: steps.changes.outputs.src == 'true'
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  postgres:
+    name: Build postgres
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tags:
+          - postgres_14
+          - postgres_15
+          - postgres_16
+          - postgres_17
+          - postgres_latest
+    env:
+      IMAGE_NAME: postgres
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout
@@ -388,80 +785,19 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
-  upptime:
-    name: Build upptime
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - upptime_monitor
-    env:
-      IMAGE_NAME: upptime
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
   rust:
     name: Build rust
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tags:
-          - typos
-          - sccache
-          - python
-          - sccache-server
-          - cargo-audit
-          - sccache-scheduler
           - athena
+          - cargo-audit
+          - python
+          - sccache
+          - sccache-scheduler
+          - sccache-server
+          - typos
     env:
       IMAGE_NAME: rust
       IMAGE_TAG: '${{ matrix.tags }}'
@@ -516,351 +852,15 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
 
-  bun:
-    name: Build bun
+  upptime:
+    name: Build upptime
     runs-on: ubuntu-latest
     strategy:
       matrix:
         tags:
-          - bun_latest
-          - bun_1.3
-          - bun_1
+          - upptime_monitor
     env:
-      IMAGE_NAME: bun
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-  postgres:
-    name: Build postgres
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - postgres_latest
-          - postgres_17
-          - postgres_16
-          - postgres_14
-          - postgres_15
-    env:
-      IMAGE_NAME: postgres
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-  clickhouse-server:
-    name: Build clickhouse-server
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - clickhouse_24.11
-          - clickhouse_25.3
-          - clickhouse_25.4
-          - clickhouse_25.5
-          - clickhouse_24.10
-          - clickhouse_25.2
-          - clickhouse_24.9
-          - clickhouse_24.7
-          - clickhouse_24.6
-          - clickhouse_24.8
-          - clickhouse_25.7
-          - clickhouse_24.12
-          - clickhouse_25.8
-          - clickhouse_25.1
-          - clickhouse_25.6
-          - clickhouse_24.3
-          - clickhouse_24.5
-    env:
-      IMAGE_NAME: clickhouse-server
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-  kubeconform:
-    name: Build kubeconform
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - kubeconform_latest
-    env:
-      IMAGE_NAME: kubeconform
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-  node:
-    name: Build node
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - node_20
-          - node_22-slim
-          - node_24-slim
-          - node_24
-          - node_22
-          - node_22.14.0_alpine
-          - node_20-slim
-    env:
-      IMAGE_NAME: node
-      IMAGE_TAG: '${{ matrix.tags }}'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-             src:
-              - '${{ env.IMAGE_NAME }}/${{ matrix.tags }}/**'
-              - '.github/workflows/ci.yaml'
-
-      - name: Log in to the Container registry
-        if: steps.changes.outputs.src == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.src == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels) for Docker
-        if: steps.changes.outputs.src == 'true'
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO }}
-          tags: |
-            type=raw,value=${{ matrix.tags }}
-            type=sha,format=short
-
-      - name: Build and push
-        if: steps.changes.outputs.src == 'true'
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: ${{ github.workspace }}
-          file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
-
-      - name: Image digest
-        if: steps.changes.outputs.src == 'true'
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-  debezium:
-    name: Build debezium
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tags:
-          - debezium_2.0.0.Beta2
-          - debezium_3.0.0.Final
-          - debezium_2.0.0.Beta1
-          - debezium_1.9.5.Final
-    env:
-      IMAGE_NAME: debezium
+      IMAGE_NAME: upptime
       IMAGE_TAG: '${{ matrix.tags }}'
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ uv run python gen.py --help
 
 # Inspect recent image/workflow changes
 git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso
+
+# Inspect commits since a specific automation run
+git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master
+
+# Dead-code evidence (exclude tests)
+rg -n "<symbol>" . --glob '!**/*test*' --glob '!**/*spec*'
 ```
 
 ### CI/CD Pipeline
@@ -110,6 +116,12 @@ CI only builds images when their specific directories change, using GitHub Actio
 - Monitor `<image_name>/<image_tag>/**` paths
 - Trigger builds only for modified images
 - Include workflow file changes as build triggers
+
+## Maintenance Memory
+
+- Keep durable maintenance notes in `docs/knowledge/core-memory.md`.
+- Keep the memory index in `docs/INDEX.md`.
+- Do not create dated review docs like `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`.
 
 ## Development Dependencies
 

--- a/README.md
+++ b/README.md
@@ -112,38 +112,6 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:upptime_monitor`](#upptimeupptime_monitor)
 
 
-## `gcloud`
-
-### [`gcloud/gcloud_debian_python3`](gcloud/gcloud_debian_python3/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:gcloud_debian_python3
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:gcloud_debian_python3
-```
-
-
-### [`gcloud/gcloud_alpine_python39`](gcloud/gcloud_alpine_python39/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:gcloud_alpine_python39
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:gcloud_alpine_python39
-```
-
-
 ## `alpine`
 
 ### [`alpine/alpine_3.19`](alpine/alpine_3.19/Dockerfile)
@@ -161,35 +129,369 @@ FROM ghcr.io/duyet/docker-images:alpine_3.19
 ```
 
 
-## `docker`
+## `bun`
 
-### [`docker/docker_27_dind`](docker/docker_27_dind/Dockerfile)
+### [`bun/bun_1`](bun/bun_1/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:docker_27_dind
+docker pull ghcr.io/duyet/docker-images:bun_1
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:docker_27_dind
+FROM ghcr.io/duyet/docker-images:bun_1
 ```
 
 
-### [`docker/docker_27_cli`](docker/docker_27_cli/Dockerfile)
+### [`bun/bun_1.3`](bun/bun_1.3/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:docker_27_cli
+docker pull ghcr.io/duyet/docker-images:bun_1.3
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:docker_27_cli
+FROM ghcr.io/duyet/docker-images:bun_1.3
+```
+
+
+### [`bun/bun_latest`](bun/bun_latest/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:bun_latest
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:bun_latest
+```
+
+
+## `clickhouse-server`
+
+### [`clickhouse-server/clickhouse_24.10`](clickhouse-server/clickhouse_24.10/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.10
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.10
+```
+
+
+### [`clickhouse-server/clickhouse_24.11`](clickhouse-server/clickhouse_24.11/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.11
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.11
+```
+
+
+### [`clickhouse-server/clickhouse_24.12`](clickhouse-server/clickhouse_24.12/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.12
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.12
+```
+
+
+### [`clickhouse-server/clickhouse_24.3`](clickhouse-server/clickhouse_24.3/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.3
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.3
+```
+
+
+### [`clickhouse-server/clickhouse_24.5`](clickhouse-server/clickhouse_24.5/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.5
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.5
+```
+
+
+### [`clickhouse-server/clickhouse_24.6`](clickhouse-server/clickhouse_24.6/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.6
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.6
+```
+
+
+### [`clickhouse-server/clickhouse_24.7`](clickhouse-server/clickhouse_24.7/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.7
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.7
+```
+
+
+### [`clickhouse-server/clickhouse_24.8`](clickhouse-server/clickhouse_24.8/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.8
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.8
+```
+
+
+### [`clickhouse-server/clickhouse_24.9`](clickhouse-server/clickhouse_24.9/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.9
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.9
+```
+
+
+### [`clickhouse-server/clickhouse_25.1`](clickhouse-server/clickhouse_25.1/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.1
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.1
+```
+
+
+### [`clickhouse-server/clickhouse_25.2`](clickhouse-server/clickhouse_25.2/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.2
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.2
+```
+
+
+### [`clickhouse-server/clickhouse_25.3`](clickhouse-server/clickhouse_25.3/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.3
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.3
+```
+
+
+### [`clickhouse-server/clickhouse_25.4`](clickhouse-server/clickhouse_25.4/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.4
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.4
+```
+
+
+### [`clickhouse-server/clickhouse_25.5`](clickhouse-server/clickhouse_25.5/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.5
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.5
+```
+
+
+### [`clickhouse-server/clickhouse_25.6`](clickhouse-server/clickhouse_25.6/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.6
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.6
+```
+
+
+### [`clickhouse-server/clickhouse_25.7`](clickhouse-server/clickhouse_25.7/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.7
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.7
+```
+
+
+### [`clickhouse-server/clickhouse_25.8`](clickhouse-server/clickhouse_25.8/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.8
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.8
+```
+
+
+## `debezium`
+
+### [`debezium/debezium_1.9.5.Final`](debezium/debezium_1.9.5.Final/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:debezium_1.9.5.Final
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:debezium_1.9.5.Final
+```
+
+
+### [`debezium/debezium_2.0.0.Beta1`](debezium/debezium_2.0.0.Beta1/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1
+```
+
+
+### [`debezium/debezium_2.0.0.Beta2`](debezium/debezium_2.0.0.Beta2/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:debezium_2.0.0.Beta2
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:debezium_2.0.0.Beta2
+```
+
+
+### [`debezium/debezium_3.0.0.Final`](debezium/debezium_3.0.0.Final/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:debezium_3.0.0.Final
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:debezium_3.0.0.Final
 ```
 
 
@@ -207,6 +509,271 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:stable-slim
+```
+
+
+## `docker`
+
+### [`docker/docker_27_cli`](docker/docker_27_cli/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:docker_27_cli
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:docker_27_cli
+```
+
+
+### [`docker/docker_27_dind`](docker/docker_27_dind/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:docker_27_dind
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:docker_27_dind
+```
+
+
+## `gcloud`
+
+### [`gcloud/gcloud_alpine_python39`](gcloud/gcloud_alpine_python39/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:gcloud_alpine_python39
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:gcloud_alpine_python39
+```
+
+
+### [`gcloud/gcloud_debian_python3`](gcloud/gcloud_debian_python3/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:gcloud_debian_python3
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:gcloud_debian_python3
+```
+
+
+## `kubeconform`
+
+### [`kubeconform/kubeconform_latest`](kubeconform/kubeconform_latest/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:kubeconform_latest
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:kubeconform_latest
+```
+
+
+## `node`
+
+### [`node/node_20`](node/node_20/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_20
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_20
+```
+
+
+### [`node/node_20-slim`](node/node_20-slim/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_20-slim
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_20-slim
+```
+
+
+### [`node/node_22`](node/node_22/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_22
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_22
+```
+
+
+### [`node/node_22-slim`](node/node_22-slim/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_22-slim
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_22-slim
+```
+
+
+### [`node/node_22.14.0_alpine`](node/node_22.14.0_alpine/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_22.14.0_alpine
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_22.14.0_alpine
+```
+
+
+### [`node/node_24`](node/node_24/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_24
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_24
+```
+
+
+### [`node/node_24-slim`](node/node_24-slim/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:node_24-slim
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:node_24-slim
+```
+
+
+## `postgres`
+
+### [`postgres/postgres_14`](postgres/postgres_14/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:postgres_14
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:postgres_14
+```
+
+
+### [`postgres/postgres_15`](postgres/postgres_15/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:postgres_15
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:postgres_15
+```
+
+
+### [`postgres/postgres_16`](postgres/postgres_16/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:postgres_16
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:postgres_16
+```
+
+
+### [`postgres/postgres_17`](postgres/postgres_17/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:postgres_17
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:postgres_17
+```
+
+
+### [`postgres/postgres_latest`](postgres/postgres_latest/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:postgres_latest
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:postgres_latest
 ```
 
 
@@ -274,82 +841,20 @@ FROM ghcr.io/duyet/docker-images:redis_8
 ```
 
 
-## `upptime`
-
-### [`upptime/upptime_monitor`](upptime/upptime_monitor/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:upptime_monitor
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:upptime_monitor
-```
-
-
 ## `rust`
 
-### [`rust/typos`](rust/typos/Dockerfile)
+### [`rust/athena`](rust/athena/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:typos
+docker pull ghcr.io/duyet/docker-images:athena
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:typos
-```
-
-
-### [`rust/sccache`](rust/sccache/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:sccache
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:sccache
-```
-
-
-### [`rust/python`](rust/python/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:python
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:python
-```
-
-
-### [`rust/sccache-server`](rust/sccache-server/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:sccache-server
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:sccache-server
+FROM ghcr.io/duyet/docker-images:athena
 ```
 
 
@@ -368,6 +873,36 @@ FROM ghcr.io/duyet/docker-images:cargo-audit
 ```
 
 
+### [`rust/python`](rust/python/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:python
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:python
+```
+
+
+### [`rust/sccache`](rust/sccache/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:sccache
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:sccache
+```
+
+
 ### [`rust/sccache-scheduler`](rust/sccache-scheduler/Dockerfile)
 
 Install from the command line
@@ -383,585 +918,50 @@ FROM ghcr.io/duyet/docker-images:sccache-scheduler
 ```
 
 
-### [`rust/athena`](rust/athena/Dockerfile)
+### [`rust/sccache-server`](rust/sccache-server/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:athena
+docker pull ghcr.io/duyet/docker-images:sccache-server
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:athena
+FROM ghcr.io/duyet/docker-images:sccache-server
 ```
 
 
-## `bun`
-
-### [`bun/bun_latest`](bun/bun_latest/Dockerfile)
+### [`rust/typos`](rust/typos/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:bun_latest
+docker pull ghcr.io/duyet/docker-images:typos
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:bun_latest
+FROM ghcr.io/duyet/docker-images:typos
 ```
 
 
-### [`bun/bun_1.3`](bun/bun_1.3/Dockerfile)
+## `upptime`
+
+### [`upptime/upptime_monitor`](upptime/upptime_monitor/Dockerfile)
 
 Install from the command line
 
 ```bash
-docker pull ghcr.io/duyet/docker-images:bun_1.3
+docker pull ghcr.io/duyet/docker-images:upptime_monitor
 ```
 
 Use as base image in Dockerfile:
 
 ```Dockerfile
-FROM ghcr.io/duyet/docker-images:bun_1.3
-```
-
-
-### [`bun/bun_1`](bun/bun_1/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:bun_1
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:bun_1
-```
-
-
-## `postgres`
-
-### [`postgres/postgres_latest`](postgres/postgres_latest/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:postgres_latest
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:postgres_latest
-```
-
-
-### [`postgres/postgres_17`](postgres/postgres_17/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:postgres_17
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:postgres_17
-```
-
-
-### [`postgres/postgres_16`](postgres/postgres_16/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:postgres_16
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:postgres_16
-```
-
-
-### [`postgres/postgres_14`](postgres/postgres_14/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:postgres_14
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:postgres_14
-```
-
-
-### [`postgres/postgres_15`](postgres/postgres_15/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:postgres_15
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:postgres_15
-```
-
-
-## `clickhouse-server`
-
-### [`clickhouse-server/clickhouse_24.11`](clickhouse-server/clickhouse_24.11/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.11
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.11
-```
-
-
-### [`clickhouse-server/clickhouse_25.3`](clickhouse-server/clickhouse_25.3/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.3
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.3
-```
-
-
-### [`clickhouse-server/clickhouse_25.4`](clickhouse-server/clickhouse_25.4/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.4
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.4
-```
-
-
-### [`clickhouse-server/clickhouse_25.5`](clickhouse-server/clickhouse_25.5/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.5
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.5
-```
-
-
-### [`clickhouse-server/clickhouse_24.10`](clickhouse-server/clickhouse_24.10/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.10
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.10
-```
-
-
-### [`clickhouse-server/clickhouse_25.2`](clickhouse-server/clickhouse_25.2/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.2
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.2
-```
-
-
-### [`clickhouse-server/clickhouse_24.9`](clickhouse-server/clickhouse_24.9/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.9
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.9
-```
-
-
-### [`clickhouse-server/clickhouse_24.7`](clickhouse-server/clickhouse_24.7/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.7
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.7
-```
-
-
-### [`clickhouse-server/clickhouse_24.6`](clickhouse-server/clickhouse_24.6/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.6
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.6
-```
-
-
-### [`clickhouse-server/clickhouse_24.8`](clickhouse-server/clickhouse_24.8/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.8
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.8
-```
-
-
-### [`clickhouse-server/clickhouse_25.7`](clickhouse-server/clickhouse_25.7/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.7
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.7
-```
-
-
-### [`clickhouse-server/clickhouse_24.12`](clickhouse-server/clickhouse_24.12/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.12
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.12
-```
-
-
-### [`clickhouse-server/clickhouse_25.8`](clickhouse-server/clickhouse_25.8/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.8
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.8
-```
-
-
-### [`clickhouse-server/clickhouse_25.1`](clickhouse-server/clickhouse_25.1/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.1
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.1
-```
-
-
-### [`clickhouse-server/clickhouse_25.6`](clickhouse-server/clickhouse_25.6/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_25.6
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_25.6
-```
-
-
-### [`clickhouse-server/clickhouse_24.3`](clickhouse-server/clickhouse_24.3/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.3
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.3
-```
-
-
-### [`clickhouse-server/clickhouse_24.5`](clickhouse-server/clickhouse_24.5/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:clickhouse_24.5
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:clickhouse_24.5
-```
-
-
-## `kubeconform`
-
-### [`kubeconform/kubeconform_latest`](kubeconform/kubeconform_latest/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:kubeconform_latest
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:kubeconform_latest
-```
-
-
-## `node`
-
-### [`node/node_20`](node/node_20/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_20
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_20
-```
-
-
-### [`node/node_22-slim`](node/node_22-slim/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_22-slim
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_22-slim
-```
-
-
-### [`node/node_24-slim`](node/node_24-slim/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_24-slim
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_24-slim
-```
-
-
-### [`node/node_24`](node/node_24/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_24
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_24
-```
-
-
-### [`node/node_22`](node/node_22/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_22
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_22
-```
-
-
-### [`node/node_22.14.0_alpine`](node/node_22.14.0_alpine/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_22.14.0_alpine
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_22.14.0_alpine
-```
-
-
-### [`node/node_20-slim`](node/node_20-slim/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:node_20-slim
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:node_20-slim
-```
-
-
-## `debezium`
-
-### [`debezium/debezium_2.0.0.Beta2`](debezium/debezium_2.0.0.Beta2/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:debezium_2.0.0.Beta2
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:debezium_2.0.0.Beta2
-```
-
-
-### [`debezium/debezium_3.0.0.Final`](debezium/debezium_3.0.0.Final/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:debezium_3.0.0.Final
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:debezium_3.0.0.Final
-```
-
-
-### [`debezium/debezium_2.0.0.Beta1`](debezium/debezium_2.0.0.Beta1/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1
-```
-
-
-### [`debezium/debezium_1.9.5.Final`](debezium/debezium_1.9.5.Final/Dockerfile)
-
-Install from the command line
-
-```bash
-docker pull ghcr.io/duyet/docker-images:debezium_1.9.5.Final
-```
-
-Use as base image in Dockerfile:
-
-```Dockerfile
-FROM ghcr.io/duyet/docker-images:debezium_1.9.5.Final
+FROM ghcr.io/duyet/docker-images:upptime_monitor
 ```
 
 <!-- END IMAGE LIST -->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,3 @@
+# Docs Index
+
+- [Core Memory](knowledge/core-memory.md)

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -1,0 +1,20 @@
+# Core Memory
+
+This file stores durable maintenance notes for automation and contributors.
+
+## Recent-change audit workflow
+
+- Scan recent commits by date window:
+  - `git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master`
+- Scan fallback window when no new commits are found:
+  - `git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso master`
+
+## Dead-code evidence workflow
+
+- Only mark code dead after zero non-test references:
+  - `rg -n '<symbol>' . --glob '!**/*test*' --glob '!**/*spec*'`
+
+## Repo notes
+
+- `AGENTS.md` is a symlink to `CLAUDE.md`; update `CLAUDE.md` for shared instructions.
+- Keep maintenance knowledge in this file and avoid dated review artifacts.

--- a/gen.py
+++ b/gen.py
@@ -15,11 +15,11 @@ def scan_images(repo_root):
 
     # Scan the image_name is the directory in top level
     # The image_tag is the directory in the image_name directory
-    for image_name in os.listdir(repo_root):
+    for image_name in sorted(os.listdir(repo_root)):
         image_dir = repo_root / image_name
         if image_dir.is_dir():
             projects[image_name] = []
-            for image_tag in os.listdir(image_dir):
+            for image_tag in sorted(os.listdir(image_dir)):
                 check = image_dir / image_tag / "Dockerfile"
                 if check.is_file():
                     projects[image_name].append(image_tag)


### PR DESCRIPTION
## Summary
- sort `scan_images()` directory traversal so generated workflow/README order is deterministic
- regenerate `.github/workflows/ci.yaml` and README image section from the new deterministic order
- add durable maintenance memory docs (`docs/knowledge/core-memory.md`, `docs/INDEX.md`) and reference them from `CLAUDE.md`
- add explicit commands in `CLAUDE.md` for since-last-run commit scans and dead-code evidence searches

## Why
- recent commit `230fc78` changed `gen.py`; scanning showed ordering remained filesystem-dependent, which can cause noisy generated diffs
- automation policy now prefers durable core memory over dated `docs/reviews/code-smell-dead-code-*.md`

## Verification
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py --dry-run`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py`
- `python3 -m py_compile gen.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive developer maintenance guidelines and operational workflows documentation.
  * Reorganized Docker image reference lists in README for improved navigation.
  * Extended developer guidance with repository inspection commands.

* **Chores**
  * Improved consistency and determinism in automated CI/CD workflows and build processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->