### PR TITLE
fix(ci): recover main image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
     env:
       IMAGE_NAME: alpine
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,7 +69,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -91,6 +92,7 @@ jobs:
     env:
       IMAGE_NAME: bun
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,7 +133,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -168,6 +170,7 @@ jobs:
     env:
       IMAGE_NAME: clickhouse-server
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -208,7 +211,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -232,6 +235,7 @@ jobs:
     env:
       IMAGE_NAME: debezium
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -272,7 +276,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -293,6 +297,7 @@ jobs:
     env:
       IMAGE_NAME: debian
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -333,7 +338,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -355,6 +360,7 @@ jobs:
     env:
       IMAGE_NAME: docker
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -395,7 +401,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -417,6 +423,7 @@ jobs:
     env:
       IMAGE_NAME: gcloud
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -457,7 +464,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -478,6 +485,7 @@ jobs:
     env:
       IMAGE_NAME: kubeconform
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -518,7 +526,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -545,6 +553,7 @@ jobs:
     env:
       IMAGE_NAME: node
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -585,7 +594,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -610,6 +619,7 @@ jobs:
     env:
       IMAGE_NAME: postgres
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -650,7 +660,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -672,6 +682,7 @@ jobs:
     env:
       IMAGE_NAME: python
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -712,7 +723,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -734,6 +745,7 @@ jobs:
     env:
       IMAGE_NAME: redis
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -774,7 +786,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -801,6 +813,7 @@ jobs:
     env:
       IMAGE_NAME: rust
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -841,7 +854,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -862,6 +875,7 @@ jobs:
     env:
       IMAGE_NAME: upptime
       IMAGE_TAG: '${{ matrix.tags }}'
+      IMAGE_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -902,7 +916,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' -
 
 # Dead-code evidence (exclude tests)
 rg -n "<symbol>" . --glob '!**/*test*' --glob '!**/*spec*'
+
+# Check whether a base image is multi-arch before enabling arm64
+docker buildx imagetools inspect <base-image:tag>
 ```
 
 ### CI/CD Pipeline

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -14,6 +14,12 @@ This file stores durable maintenance notes for automation and contributors.
 - Only mark code dead after zero non-test references:
   - `rg -n '<symbol>' . --glob '!**/*test*' --glob '!**/*spec*'`
 
+## CI architecture workflow
+
+- Check whether a base image tag is multi-arch before enabling `linux/arm64`:
+  - `docker buildx imagetools inspect <base-image:tag>`
+- Keep `gcloud/*` and `debezium/*` on `linux/amd64` in generated CI while their upstream base tags publish single-arch manifests.
+
 ## Repo notes
 
 - `AGENTS.md` is a symlink to `CLAUDE.md`; update `CLAUDE.md` for shared instructions.

--- a/gen.py
+++ b/gen.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 import jinja2
 
+DEFAULT_PLATFORMS = "linux/amd64,linux/arm64"
+SINGLE_ARCH_IMAGES = {"debezium", "gcloud"}
+
 
 def scan_images(repo_root):
     """
@@ -66,6 +69,7 @@ jobs:
     env:
       IMAGE_NAME: {{ image_name }}
       IMAGE_TAG: '{% raw %}${{ matrix.tags }}{% endraw %}'
+      IMAGE_PLATFORMS: {{ image_platforms[image_name] }}
     {%- raw %}
     steps:
       - name: Checkout
@@ -107,7 +111,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.IMAGE_PLATFORMS }}
           context: ${{ github.workspace }}
           file: ./${{ env.IMAGE_NAME }}/${{ env.IMAGE_TAG }}/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -168,7 +172,11 @@ def build_workflows(images):
     template = jinja2.Template(get_template_workflows())
 
     # Build the workflows
-    workflows = template.render(images=images)
+    image_platforms = {
+        name: "linux/amd64" if name in SINGLE_ARCH_IMAGES else DEFAULT_PLATFORMS
+        for name in images
+    }
+    workflows = template.render(images=images, image_platforms=image_platforms)
 
     return workflows
 

--- a/upptime/upptime_monitor/Dockerfile
+++ b/upptime/upptime_monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:22
 
 USER root
 WORKDIR /app


### PR DESCRIPTION
## Summary
- keep generated default platforms as `linux/amd64,linux/arm64`
- force generated CI to `linux/amd64` for `gcloud/*` and `debezium/*` images
- upgrade `upptime/upptime_monitor` base image from `node:12` to `node:22`
- add architecture-check command and CI platform note to maintenance docs

## Evidence from failing main run
Main run: https://github.com/duyet/docker-images/actions/runs/25762368051
- `Build gcloud (gcloud_alpine_python39)` failed with `.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture` on `linux/arm64` (job `75666531418`).
- `Build debezium (debezium_1.9.5.Final)` failed with the same `Invalid ELF image` arm64 failure (job `75666531509`); other debezium tags were cancelled by fail-fast.
- `Build upptime (upptime_monitor)` failed on `npm install` under `node:12` (`node-libcurl@5.0.2 install` exit 1, job `75666531508`).
- `docker buildx imagetools inspect google/cloud-sdk:alpine` and `... debezium/connect:1.9.5.Final` return single-manifest output, consistent with amd64-only bases.

## Verification
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python gen.py --dry-run`
- `python3 -m py_compile gen.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CI now supports multi-architecture builds (ARM64 and x86-64) for most Docker images.

* **Chores**
  * Upgraded Node.js base image from version 12 to version 22 in the monitor component.

* **Documentation**
  * Added guidance on verifying base image architecture support before enabling ARM64 builds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->