### PR TITLE
fix(ci): limit rust sccache to amd64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -813,7 +813,7 @@ jobs:
     env:
       IMAGE_NAME: rust
       IMAGE_TAG: '${{ matrix.tags }}'
-      IMAGE_PLATFORMS: linux/amd64,linux/arm64
+      IMAGE_PLATFORMS: ${{ contains(fromJSON('["sccache"]'), matrix.tags) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -813,7 +813,7 @@ jobs:
     env:
       IMAGE_NAME: rust
       IMAGE_TAG: '${{ matrix.tags }}'
-      IMAGE_PLATFORMS: ${{ contains(fromJSON('["sccache"]'), matrix.tags) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+      IMAGE_PLATFORMS: ${{ contains(fromJSON('["sccache", "sccache-scheduler", "sccache-server"]'), matrix.tags) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ docker buildx imagetools inspect <base-image:tag>
 
 GitHub Actions automatically:
 - Builds images for modified directories only (using path filters)
-- Uses linux/amd64 + linux/arm64 by default, with per-image/per-tag amd64 overrides when upstream or build features are arch-limited (`gcloud/*`, `debezium/*`, `rust/sccache`)
+- Uses linux/amd64 + linux/arm64 by default, with per-image/per-tag amd64 overrides when upstream or build features are arch-limited (`gcloud/*`, `debezium/*`, `rust/sccache*`)
 - Tags images with:
   - The image tag name
   - Git SHA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ uv sync
 # Generate workflows and README
 uv run python gen.py
 
+# Generate when default uv cache path is not writable
+UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py
+
 # Preview changes (dry run)
 uv run python gen.py --dry-run
 
@@ -74,7 +77,7 @@ docker buildx imagetools inspect <base-image:tag>
 
 GitHub Actions automatically:
 - Builds images for modified directories only (using path filters)
-- Supports multi-architecture builds (linux/amd64, linux/arm64)
+- Uses linux/amd64 + linux/arm64 by default, with per-image/per-tag amd64 overrides when upstream or build features are arch-limited (`gcloud/*`, `debezium/*`, `rust/sccache`)
 - Tags images with:
   - The image tag name
   - Git SHA

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -19,6 +19,9 @@ This file stores durable maintenance notes for automation and contributors.
 - Check whether a base image tag is multi-arch before enabling `linux/arm64`:
   - `docker buildx imagetools inspect <base-image:tag>`
 - Keep `gcloud/*` and `debezium/*` on `linux/amd64` in generated CI while their upstream base tags publish single-arch manifests.
+- Keep `rust/sccache` on `linux/amd64` by tag override because `sccache-dist` fails to compile on arm64 (`Distributed compilation is only supported on Linux/x86_64 and FreeBSD`).
+- If default uv cache path is not writable in sandbox/worktree runs, use:
+  - `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py`
 
 ## Repo notes
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -19,7 +19,7 @@ This file stores durable maintenance notes for automation and contributors.
 - Check whether a base image tag is multi-arch before enabling `linux/arm64`:
   - `docker buildx imagetools inspect <base-image:tag>`
 - Keep `gcloud/*` and `debezium/*` on `linux/amd64` in generated CI while their upstream base tags publish single-arch manifests.
-- Keep `rust/sccache` on `linux/amd64` by tag override because `sccache-dist` fails to compile on arm64 (`Distributed compilation is only supported on Linux/x86_64 and FreeBSD`).
+- Keep `rust/sccache*` tags (`sccache`, `sccache-server`, `sccache-scheduler`) on `linux/amd64` by tag override because `sccache-dist` fails to compile on arm64 (`Distributed compilation is only supported on Linux/x86_64 and FreeBSD`).
 - If default uv cache path is not writable in sandbox/worktree runs, use:
   - `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py`
 

--- a/gen.py
+++ b/gen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 import os
 from pathlib import Path
 
@@ -8,6 +9,9 @@ import jinja2
 
 DEFAULT_PLATFORMS = "linux/amd64,linux/arm64"
 SINGLE_ARCH_IMAGES = {"debezium", "gcloud"}
+SINGLE_ARCH_TAGS = {
+    "rust": {"sccache"},
+}
 
 
 def scan_images(repo_root):
@@ -31,6 +35,23 @@ def scan_images(repo_root):
     projects = {k: v for k, v in projects.items() if v}
 
     return projects
+
+
+def resolve_platform_expression(image_name, image_tags):
+    """Resolve workflow expression for job-level IMAGE_PLATFORMS."""
+    if image_name in SINGLE_ARCH_IMAGES:
+        return "linux/amd64"
+
+    single_arch_tags = sorted(SINGLE_ARCH_TAGS.get(image_name, set()))
+    if not single_arch_tags:
+        return DEFAULT_PLATFORMS
+
+    overrides = json.dumps(single_arch_tags)
+    return (
+        "${{ contains(fromJSON('"
+        + overrides
+        + "'), matrix.tags) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}"
+    )
 
 
 def get_template_workflows():
@@ -173,8 +194,8 @@ def build_workflows(images):
 
     # Build the workflows
     image_platforms = {
-        name: "linux/amd64" if name in SINGLE_ARCH_IMAGES else DEFAULT_PLATFORMS
-        for name in images
+        name: resolve_platform_expression(name, image_tags)
+        for name, image_tags in images.items()
     }
     workflows = template.render(images=images, image_platforms=image_platforms)
 

--- a/gen.py
+++ b/gen.py
@@ -10,7 +10,7 @@ import jinja2
 DEFAULT_PLATFORMS = "linux/amd64,linux/arm64"
 SINGLE_ARCH_IMAGES = {"debezium", "gcloud"}
 SINGLE_ARCH_TAGS = {
-    "rust": {"sccache"},
+    "rust": {"sccache", "sccache-scheduler", "sccache-server"},
 }
 
 


### PR DESCRIPTION
## Summary
- fix failing  main workflow by restricting  matrix entry to  through generated platform expression
- keep existing  and  single-arch overrides untouched
- sync durable workflow notes in  and  (including sandbox-safe  command)

## Evidence
- failing main run: https://github.com/duyet/docker-images/actions/runs/25763257798
- failing job:  https://github.com/duyet/docker-images/actions/runs/25763257798/job/75669534200
- concrete error:  while building arm64 

## Verification
- Generated workflows to /Users/duet/project/docker-images/.github/workflows/ci.yaml
Generated README.md
- inspected generated  to confirm only  is forced to amd64 via matrix-tag expression

## Summary by Sourcery

Constrain rust sccache CI builds to amd64 via generated workflow logic and update durable documentation accordingly.

Bug Fixes:
- Prevent failing arm64 rust/sccache builds by introducing a per-tag amd64-only platform override in the generated CI workflows.

Enhancements:
- Refactor workflow generation to support per-image and per-tag platform expressions while preserving existing single-arch image overrides.

Documentation:
- Document the new per-tag amd64 override for rust/sccache and add guidance for using a local uv cache directory when the default path is not writable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline platform configuration for optimized multi-architecture builds.
  * Enhanced development workflow documentation with cache directory handling for local development environments.
  * Updated maintenance notes for CI infrastructure and build compatibility across different processor architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->