### PR TITLE
chore(maintenance): tighten generator helper and audit workflow notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,9 @@ git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --dat
 # Inspect commits since a specific automation run
 git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master
 
+# Inspect minimal diffs for one commit and selected files
+git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>
+
 # Dead-code evidence (exclude tests)
 rg -n "<symbol>" . --glob '!**/*test*' --glob '!**/*spec*'
 
@@ -128,6 +131,7 @@ CI only builds images when their specific directories change, using GitHub Actio
 - Keep durable maintenance notes in `docs/knowledge/core-memory.md`.
 - Keep the memory index in `docs/INDEX.md`.
 - Do not create dated review docs like `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`.
+- If worktree git metadata locks block writes (for example `.git/worktrees/.../HEAD.lock`), rerun git-write steps from the canonical checkout.
 
 ## Development Dependencies
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -8,6 +8,8 @@ This file stores durable maintenance notes for automation and contributors.
   - `git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master`
 - Scan fallback window when no new commits are found:
   - `git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso master`
+- Inspect a single commit with minimal context for evidence-first triage:
+  - `git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>`
 
 ## Dead-code evidence workflow
 
@@ -27,3 +29,4 @@ This file stores durable maintenance notes for automation and contributors.
 
 - `AGENTS.md` is a symlink to `CLAUDE.md`; update `CLAUDE.md` for shared instructions.
 - Keep maintenance knowledge in this file and avoid dated review artifacts.
+- If `.git/worktrees/.../*.lock` blocks git writes in a linked worktree, continue from the canonical checkout and keep the same branch.

--- a/gen.py
+++ b/gen.py
@@ -37,7 +37,7 @@ def scan_images(repo_root):
     return projects
 
 
-def resolve_platform_expression(image_name, image_tags):
+def resolve_platform_expression(image_name):
     """Resolve workflow expression for job-level IMAGE_PLATFORMS."""
     if image_name in SINGLE_ARCH_IMAGES:
         return "linux/amd64"
@@ -50,7 +50,9 @@ def resolve_platform_expression(image_name, image_tags):
     return (
         "${{ contains(fromJSON('"
         + overrides
-        + "'), matrix.tags) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}"
+        + "'), matrix.tags) && 'linux/amd64' || '"
+        + DEFAULT_PLATFORMS
+        + "' }}"
     )
 
 
@@ -194,8 +196,7 @@ def build_workflows(images):
 
     # Build the workflows
     image_platforms = {
-        name: resolve_platform_expression(name, image_tags)
-        for name, image_tags in images.items()
+        name: resolve_platform_expression(name) for name in images
     }
     workflows = template.render(images=images, image_platforms=image_platforms)
 


### PR DESCRIPTION
## Summary
- remove an unused `image_tags` parameter from `resolve_platform_expression` in `gen.py`
- reuse `DEFAULT_PLATFORMS` in the generated tag-override expression to avoid duplicated literals
- add evidence-first audit commands and worktree-lock fallback notes to `CLAUDE.md` and `docs/knowledge/core-memory.md`

## Why
- recent maintenance scan found a small code smell (unused parameter) in the generator helper
- this keeps behavior unchanged while improving readability and reducing drift risk
- documents a proven workflow for commit-level triage and worktree lock handling

## Verification
- `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py`
- `PYTHONPYCACHEPREFIX=$PWD/.cache/python python3 -m py_compile gen.py`
