### PR TITLE
chore(maintenance): refresh audit commands and uv config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,9 @@ git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' -
 # Inspect minimal diffs for one commit and selected files
 git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>
 
+# Verify post-merge CI for a specific commit on master
+gh run list --branch master --commit "<merge_sha>" --json databaseId,displayTitle,status,conclusion,url --limit 20
+
 # Dead-code evidence (exclude tests)
 rg -n "<symbol>" . --glob '!**/*test*' --glob '!**/*spec*'
 
@@ -132,6 +135,7 @@ CI only builds images when their specific directories change, using GitHub Actio
 - Keep the memory index in `docs/INDEX.md`.
 - Do not create dated review docs like `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`.
 - If worktree git metadata locks block writes (for example `.git/worktrees/.../HEAD.lock`), rerun git-write steps from the canonical checkout.
+- If a linked worktree opens in detached `HEAD`, create a branch from `master` before edits.
 
 ## Development Dependencies
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -10,6 +10,8 @@ This file stores durable maintenance notes for automation and contributors.
   - `git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso master`
 - Inspect a single commit with minimal context for evidence-first triage:
   - `git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>`
+- Verify post-merge CI for a merge commit on `master`:
+  - `gh run list --branch master --commit "<merge_sha>" --json databaseId,displayTitle,status,conclusion,url --limit 20`
 
 ## Dead-code evidence workflow
 
@@ -30,3 +32,4 @@ This file stores durable maintenance notes for automation and contributors.
 - `AGENTS.md` is a symlink to `CLAUDE.md`; update `CLAUDE.md` for shared instructions.
 - Keep maintenance knowledge in this file and avoid dated review artifacts.
 - If `.git/worktrees/.../*.lock` blocks git writes in a linked worktree, continue from the canonical checkout and keep the same branch.
+- If a linked worktree opens in detached `HEAD`, create a branch from `master` before editing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ dependencies = [
     "jinja2",
 ]
 
-[tool.uv]
-dev-dependencies = []
+[dependency-groups]
+dev = []


### PR DESCRIPTION
## Summary
- add two proven maintenance commands to repo guidance: post-merge CI lookup by merge SHA and detached-HEAD branch bootstrap
- sync the same workflow notes into durable memory (`docs/knowledge/core-memory.md`)
- migrate deprecated uv config from `[tool.uv].dev-dependencies` to `[dependency-groups].dev`

## Evidence and findings in this run
- Commit window since last run (`2026-05-13T21:00:54Z`) contained one maintenance commit (`34af34f`) plus merge commit (`2d6f51d`); no new runtime code changes in image Dockerfiles/workflow logic.
- `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py --dry-run` previously emitted a deprecation warning for `tool.uv.dev-dependencies`; warning is gone after this change.
- No zero-reference dead code found in the modified non-test files in scope.

## Verification
- `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py --dry-run`
- `git diff --check`

## Summary by Sourcery

Document new maintenance practices and update dependency configuration for uv.

Enhancements:
- Add guidance for checking post-merge CI status by merge SHA in contributor docs and durable maintenance notes.
- Add guidance for creating a branch from master when a linked worktree opens in detached HEAD.
- Migrate deprecated uv dev-dependencies configuration in pyproject.toml to the new dependency-groups table.

Documentation:
- Sync core maintenance commands and workflows into docs/knowledge/core-memory.md for long-term reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced repository guidance with CI verification procedures and linked worktree management instructions.

* **Chores**
  * Updated development dependencies configuration structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->