### PR TITLE
chore(maintenance): add 24h fallback audit command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,9 @@ git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --dat
 # Inspect commits since a specific automation run
 git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master
 
+# Inspect commits from a short fallback window when no new commits since last run
+git log --since='24 hours ago' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master
+
 # Inspect minimal diffs for one commit and selected files
 git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -6,6 +6,8 @@ This file stores durable maintenance notes for automation and contributors.
 
 - Scan recent commits by date window:
   - `git log --since='<last_run_iso>' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master`
+- Scan a short fallback window when no commits appear since the last run:
+  - `git log --since='24 hours ago' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict master`
 - Scan fallback window when no new commits are found:
   - `git log --since='7 days ago' --name-status --pretty='format:=== %H %ad %s' --date=iso master`
 - Inspect a single commit with minimal context for evidence-first triage:


### PR DESCRIPTION
## Summary
- add a 24-hour fallback commit-scan command to [`CLAUDE.md`](CLAUDE.md) and [`docs/knowledge/core-memory.md`](docs/knowledge/core-memory.md)
- keep durable maintenance workflow aligned with this automation's "since last run -> 24h -> 7 days" evidence path

## Evidence from this run
- recent changes since last run (`2026-05-15T14:22:58Z`): commit `b4eb243f5989aaab0c788603cab1dc4237baea59` touching `CLAUDE.md`, `docs/knowledge/core-memory.md`, `pyproject.toml`
- no runtime code-path changes found in that window
- no `docs/reviews/code-smell-dead-code-*.md` artifacts found in repo

## Validation
- `UV_CACHE_DIR=$PWD/.uv-cache uv run python gen.py --dry-run`

## Summary by Sourcery

Document a 24-hour fallback git log audit step in the maintenance guidance.

Documentation:
- Describe a 24-hour fallback commit-scan command in CLAUDE maintenance instructions.
- Add corresponding 24-hour fallback scan guidance to core maintenance knowledge docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation with enhanced commit audit workflow procedures, including additional fallback mechanisms for more comprehensive coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->