### PR TITLE
chore(maintenance): document FETCH_HEAD fallback for worktree audits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,9 @@ git log --since='24 hours ago' --name-status --pretty='format:=== %H %ad %s' --d
 # Confirm detached HEAD state and branch ownership across linked worktrees
 git worktree list --porcelain
 
+# Fetch from canonical checkout when linked-worktree metadata writes fail
+git -C <canonical_checkout_path> fetch origin --prune
+
 # Inspect minimal diffs for one commit and selected files
 git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>
 
@@ -141,6 +144,7 @@ CI only builds images when their specific directories change, using GitHub Actio
 - Keep the memory index in `docs/INDEX.md`.
 - Do not create dated review docs like `docs/reviews/code-smell-dead-code-YYYY-MM-DD.md`.
 - If worktree git metadata locks block writes (for example `.git/worktrees/.../HEAD.lock`), rerun git-write steps from the canonical checkout.
+- If linked-worktree git metadata blocks fetch writes (`.../FETCH_HEAD: Operation not permitted`), rerun fetch from the canonical checkout.
 - If a linked worktree opens in detached `HEAD`, create a branch from `master` before edits.
 
 ## Development Dependencies

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -34,6 +34,9 @@ This file stores durable maintenance notes for automation and contributors.
 - `AGENTS.md` is a symlink to `CLAUDE.md`; update `CLAUDE.md` for shared instructions.
 - Keep maintenance knowledge in this file and avoid dated review artifacts.
 - If `.git/worktrees/.../*.lock` blocks git writes in a linked worktree, continue from the canonical checkout and keep the same branch.
+- If linked-worktree git metadata blocks fetch writes (`.../FETCH_HEAD: Operation not permitted`), rerun fetch from the canonical checkout.
 - If a linked worktree opens in detached `HEAD`, create a branch from `master` before editing.
 - To confirm detached `HEAD` state and branch ownership across linked worktrees:
   - `git worktree list --porcelain`
+- To fetch safely from the canonical checkout when linked-worktree metadata writes fail:
+  - `git -C <canonical_checkout_path> fetch origin --prune`


### PR DESCRIPTION
## Summary
- scanned `origin/master` commits since `2026-05-16T21:00:13Z` (fallback 24h)
- found only docs-memory commits (`669d133`, `4edcd4e`, merge `2e64029`), with no code-path changes
- captured a repeatable linked-worktree git failure mode seen in this run: `.../FETCH_HEAD: Operation not permitted`
- updated durable maintenance guidance in `CLAUDE.md` (and `AGENTS.md` via symlink) and `docs/knowledge/core-memory.md`

## Findings (evidence-first)
- critical: none
- warning: none
- info: docs-only workflow hardening for canonical-checkout fetch fallback
- dead code: none in changed surfaces (recent changes were docs-only)
- perf regression: no measurement-backed regression signal in scanned window

## Verification
- `git log --since='2026-05-16T21:00:13Z' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict origin/master`
- `git log --since='24 hours ago' --name-status --pretty='format:=== %H %ad %s' --date=iso-strict origin/master`
- `git show --unified=0 --pretty=format:'=== %H %s' 669d133 -- CLAUDE.md docs/knowledge/core-memory.md`
- `git show --unified=0 --pretty=format:'=== %H %s' 4edcd4e -- CLAUDE.md docs/knowledge/core-memory.md`
- `git diff --check`
