### PR TITLE
chore(maintenance): refresh dead-code automation workflow memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,9 @@ git worktree list --porcelain
 # Fetch from canonical checkout when linked-worktree metadata writes fail
 git -C <canonical_checkout_path> fetch origin --prune
 
+# Create/switch feature branch from canonical checkout when linked-worktree HEAD writes fail
+git -C <canonical_checkout_path> switch -c <branch_name>
+
 # Inspect minimal diffs for one commit and selected files
 git show --unified=0 --pretty=format:'=== %H %s' <commit_sha> -- <path...>
 
@@ -146,6 +149,7 @@ CI only builds images when their specific directories change, using GitHub Actio
 - If worktree git metadata locks block writes (for example `.git/worktrees/.../HEAD.lock`), rerun git-write steps from the canonical checkout.
 - If linked-worktree git metadata blocks fetch writes (`.../FETCH_HEAD: Operation not permitted`), rerun fetch from the canonical checkout.
 - If a linked worktree opens in detached `HEAD`, create a branch from `master` before edits.
+- If the since-last-run commit window only changes docs/knowledge files, report no functional bug/perf regression findings and skip code fixes.
 
 ## Development Dependencies
 

--- a/docs/knowledge/core-memory.md
+++ b/docs/knowledge/core-memory.md
@@ -36,7 +36,10 @@ This file stores durable maintenance notes for automation and contributors.
 - If `.git/worktrees/.../*.lock` blocks git writes in a linked worktree, continue from the canonical checkout and keep the same branch.
 - If linked-worktree git metadata blocks fetch writes (`.../FETCH_HEAD: Operation not permitted`), rerun fetch from the canonical checkout.
 - If a linked worktree opens in detached `HEAD`, create a branch from `master` before editing.
+- If the since-last-run commit window only changes docs/knowledge files, report no functional bug/perf regression findings and skip code fixes.
 - To confirm detached `HEAD` state and branch ownership across linked worktrees:
   - `git worktree list --porcelain`
 - To fetch safely from the canonical checkout when linked-worktree metadata writes fail:
   - `git -C <canonical_checkout_path> fetch origin --prune`
+- To create/switch feature branches from canonical checkout when linked-worktree HEAD writes fail:
+  - `git -C <canonical_checkout_path> switch -c <branch_name>`


### PR DESCRIPTION
## Summary
- analyze commits since 2026-05-17T21:01:50Z
- document canonical checkout branch fallback for linked-worktree `HEAD.lock`
- document docs-only commit-window rule for maintenance scans

## Evidence Window
- `c78a3e6b9f4cf5fb31cfd93cc4837eab7b195890`
- `b347fd3c03edf5d0ee98fbec49d5f7977c96cca4`

## Findings
- docs-only change window; no executable-code bug/dead-code/perf findings

## Summary by Sourcery

Document maintenance workflow behavior for dead-code automation when dealing with linked worktrees and docs-only commit windows.

Documentation:
- Clarify fallback branching from the canonical checkout when linked-worktree HEAD writes fail.
- Describe the rule to treat docs-only commit windows as having no functional bug or performance findings in maintenance scans.
- Expand core maintenance notes with explicit commands for safe branching and fetching from the canonical checkout under worktree metadata issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated repository maintenance guidelines with improved guidance for managing feature branches during linked-worktree operations
* Enhanced audit workflow documentation with new rules to optimize development processes when only documentation files have changed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/docker-images/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->