### PR TITLE
fix(minio): install perl for source build checks

### DIFF
--- a/minio/minio_latest/Dockerfile
+++ b/minio/minio_latest/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.24-alpine AS builder
 ARG MINIO_REF=RELEASE.2025-10-15T17-29-55Z
 
 # Build dependencies required by MinIO's Makefile.
-RUN apk add --no-cache bash gcc git make musl-dev
+RUN apk add --no-cache bash gcc git make musl-dev perl
 
 WORKDIR /src
 RUN git clone --depth 1 --branch "${MINIO_REF}" https://github.com/minio/minio.git .


### PR DESCRIPTION
## Summary
- add `perl` to MinIO builder dependencies
- keep image/runtime behavior unchanged

## Evidence
- failing post-merge workflow: https://github.com/duyet/docker-images/actions/runs/26195247199
- failing job: https://github.com/duyet/docker-images/actions/runs/26195247199/job/77073036892
- failure excerpt: `/src/buildscripts/checkdeps.sh: line 122: perl: command not found` during `make build`

## Scope
- minimal fix in `minio/minio_latest/Dockerfile` only
