### PR TITLE
fix(node): republish orphaned node_22.14.0_alpine manifest

### DIFF
--- a/node/node_22.14.0_alpine/Dockerfile
+++ b/node/node_22.14.0_alpine/Dockerfile
@@ -1,1 +1,2 @@
+# Pinned to a specific patch release + alpine variant (unlike the floating node_22 tag).
 FROM node:22.14.0-alpine


### PR DESCRIPTION
## Problem

Pulling `ghcr.io/duyet/docker-images:node_22.14.0_alpine` fails with `manifest sha256:cf3c64… not found`.

The tag is a multi-arch manifest **index** whose amd64 (`cf3c64…`) and arm64 (`6d8198…`) child manifests no longer exist in the registry — a dangling index orphaned by the 2026-06-10 overlapping-push incident. Verified both children return 404 via `docker buildx imagetools inspect`.

`9498e33` added concurrency serialization + `fail-fast: false` to prevent **new** orphans, but never republished this already-dead tag. CI only rebuilds an image when its own path (`node/node_22.14.0_alpine/**`) or `ci.yaml` changes, so the broken index just lingers.

## Fix

Minimal change under `node/node_22.14.0_alpine/` flips the `dorny/paths-filter` so the now-serialized pipeline rebuilds and republishes just this image. Merge to `master` triggers the publish (`push:` is gated to non-PR events).

## Verify after merge
```
docker buildx imagetools inspect ghcr.io/duyet/docker-images:node_22.14.0_alpine
docker pull ghcr.io/duyet/docker-images:node_22.14.0_alpine
```

https://claude.ai/code/session_01WCX8iPViFDqFqSch77UvPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration with improved version pinning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->